### PR TITLE
Convert Lab06 notebook to Jupyter

### DIFF
--- a/Lab06.ipynb
+++ b/Lab06.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c1428b17",
+   "metadata": {},
+   "source": [
+    "# Lab 06\n",
+    "Converted from the original Mathematica notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62923302",
+   "metadata": {},
+   "source": [
+    "## Bifurcation Diagram Functionality"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c248c066",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from scipy.signal import find_peaks\n",
+    "\n",
+    "def mg(tau, beta, gamma=1, n=9.65, dt=0.1, T=100):\n",
+    "    delay_steps = int(tau/dt)\n",
+    "    history = np.full(delay_steps+1, 0.5)\n",
+    "    x = 0.5\n",
+    "    xs = []\n",
+    "    for _ in range(int(T/dt)):\n",
+    "        x_tau = history[0]\n",
+    "        dx = beta * x_tau/(1+x_tau**n) - gamma*x\n",
+    "        x = x + dx*dt\n",
+    "        history = np.append(history[1:], x)\n",
+    "        xs.append(x)\n",
+    "    t = np.linspace(0, T, len(xs))\n",
+    "    return t, np.array(xs)\n",
+    "\n",
+    "def peaks(series):\n",
+    "    idx, _ = find_peaks(series)\n",
+    "    return series[idx]\n",
+    "\n",
+    "betas = np.linspace(0, 2, 200)\n",
+    "data = []\n",
+    "for b in betas:\n",
+    "    t, x = mg(2, b)\n",
+    "    pk = peaks(x)[-20:]\n",
+    "    for p in pk:\n",
+    "        data.append((b, p))\n",
+    "\n",
+    "data = np.array(data)\n",
+    "plt.figure(figsize=(6,4))\n",
+    "plt.scatter(data[:,0], data[:,1], s=1)\n",
+    "plt.xlabel('gain (β)')\n",
+    "plt.ylabel('peaks')\n",
+    "plt.title('Mackey-Glass Bifurcation Diagram (approx.)')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0e4084d",
+   "metadata": {},
+   "source": [
+    "## Lab Waveforms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2904ce63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# synthetic waveform\n",
+    "t = np.linspace(0, 1, 1000)\n",
+    "waveform = np.sin(2*np.pi*50*t) + 0.5*np.sin(2*np.pi*120*t)\n",
+    "\n",
+    "plt.figure(figsize=(6,4))\n",
+    "plt.plot(t, waveform)\n",
+    "plt.xlabel('Time (s)')\n",
+    "plt.ylabel('Amplitude')\n",
+    "plt.title('Sample Waveform')\n",
+    "plt.show()\n",
+    "\n",
+    "# FFT\n",
+    "freq = np.fft.rfftfreq(len(t), d=t[1]-t[0])\n",
+    "fft = np.abs(np.fft.rfft(waveform))\n",
+    "\n",
+    "plt.figure(figsize=(6,4))\n",
+    "plt.plot(freq, fft)\n",
+    "plt.xlabel('Frequency (Hz)')\n",
+    "plt.ylabel('Magnitude')\n",
+    "plt.title('FFT of Waveform')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new `Lab06.ipynb` notebook approximating the original Mathematica Lab 6
- include a simple Mackey-Glass bifurcation diagram example and waveform/FFT plots

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b44ced7288323809b09d2830ef18c