### PR TITLE
Convert PS6 Mathematica notebook to Jupyter

### DIFF
--- a/PS6.ipynb
+++ b/PS6.ipynb
@@ -43,8 +43,8 @@
     "    return [1 if x <= l*math.sin(t) else 0 for x, t in zip(xs, ts)]\n",
     "\n",
     "def bn_frac(d, l, n):\n",
-    "    outcomes = [o for o in bn(d, l, n) if o != 0]\n",
-    "    return len(outcomes)/n, (2*l)/(math.pi*d)\n",
+    "    hits = sum(bn(d, l, n))\n",
+    "    return hits/n, (2*l)/(math.pi*d)\n",
     "\n",
     "bn_frac(1, 1, 1000000)\n"
    ]

--- a/PS6.ipynb
+++ b/PS6.ipynb
@@ -40,7 +40,7 @@
     "def bn(d, l, n):\n",
     "    xs = [random.uniform(0, d) for _ in range(n)]\n",
     "    ts = [random.uniform(0, math.pi/2) for _ in range(n)]\n",
-    "    return [1 if xs[i] <= l*math.sin(ts[i]) else 0 for i in range(n)]\n",
+    "    return [1 if x <= l*math.sin(t) else 0 for x, t in zip(xs, ts)]\n",
     "\n",
     "def bn_frac(d, l, n):\n",
     "    outcomes = [o for o in bn(d, l, n) if o != 0]\n",

--- a/PS6.ipynb
+++ b/PS6.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "25ffd6e3",
+   "metadata": {},
+   "source": [
+    "# Buffon's Needle Simulation\n",
+    "This section replicates Mathematica's Buffon's Needle simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3733abc7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-12T15:01:45.168446Z",
+     "iopub.status.busy": "2025-08-12T15:01:45.168258Z",
+     "iopub.status.idle": "2025-08-12T15:01:46.101475Z",
+     "shell.execute_reply": "2025-08-12T15:01:46.100877Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.63642, 0.6366197723675814)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "import random, math\n",
+    "\n",
+    "def bn(d, l, n):\n",
+    "    xs = [random.uniform(0, d) for _ in range(n)]\n",
+    "    ts = [random.uniform(0, math.pi/2) for _ in range(n)]\n",
+    "    return [1 if xs[i] <= l*math.sin(ts[i]) else 0 for i in range(n)]\n",
+    "\n",
+    "def bn_frac(d, l, n):\n",
+    "    outcomes = [o for o in bn(d, l, n) if o != 0]\n",
+    "    return len(outcomes)/n, (2*l)/(math.pi*d)\n",
+    "\n",
+    "bn_frac(1, 1, 1000000)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f6c64b8",
+   "metadata": {},
+   "source": [
+    "# Random Telegraph Signal\n",
+    "Approximation of the Mathematica code generating a random telegraph signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "835884fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-12T15:01:46.103320Z",
+     "iopub.status.busy": "2025-08-12T15:01:46.103134Z",
+     "iopub.status.idle": "2025-08-12T15:01:46.167500Z",
+     "shell.execute_reply": "2025-08-12T15:01:46.167117Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([1, 2, 3, 4, 5, 6, 7, 8, 9]), [1, -1, -1, -1, 1, -1, -1, -1, -1])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "def rts(lam, intervals):\n",
+    "    ns = np.random.poisson(lam, intervals)\n",
+    "    points = []\n",
+    "    current = 1\n",
+    "    for j, n in enumerate(ns):\n",
+    "        for i in range(n if n>0 else 1):\n",
+    "            start = j + i/(n if n>0 else 1)\n",
+    "            end = j + (i+1)/(n if n>0 else 1)\n",
+    "            points.append((start, current))\n",
+    "            points.append((end, current))\n",
+    "            current *= -1\n",
+    "    return points\n",
+    "\n",
+    "def process_rts(data, step):\n",
+    "    end_time = data[-1][0]\n",
+    "    times = np.arange(1, int(end_time), step)\n",
+    "    result = []\n",
+    "    idx = 0\n",
+    "    for t in times:\n",
+    "        while idx < len(data) and data[idx][0] <= t:\n",
+    "            idx += 1\n",
+    "        value = data[idx-1][1] if idx>0 else 1\n",
+    "        result.append(value)\n",
+    "    return times, result\n",
+    "\n",
+    "sig = rts(5, 10)\n",
+    "process_rts(sig, 1)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Recreated the "PS6" Mathematica notebook as a Jupyter notebook with a Python-based Buffon's Needle simulation.
- Added an approximate Random Telegraph Signal simulation in Python for the later sections of the original notebook.

## Testing
- `pytest`
- `jupyter nbconvert --to notebook --execute PS6.ipynb --inplace`


------
https://chatgpt.com/codex/tasks/task_e_689b561222d88323af0881f490762aab