### PR TITLE
Convert PS7.nb to Jupyter

### DIFF
--- a/PS7.ipynb
+++ b/PS7.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9b7e14a7",
+   "metadata": {},
+   "source": [
+    "# PS7 - Lorenz System"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b02cd91f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from scipy.integrate import solve_ivp\n",
+    "import matplotlib.pyplot as plt\n",
+    "from mpl_toolkits.mplot3d import Axes3D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "959133c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sigma = 10\n",
+    "rho = 10\n",
+    "beta = 8/3\n",
+    "t_span = (0, 30)\n",
+    "y0 = [1, 1, 1]\n",
+    "\n",
+    "def lorenz(t, xyz):\n",
+    "    x, y, z = xyz\n",
+    "    return [sigma*(y - x), x*(rho - z) - y, x*y - beta*z]\n",
+    "\n",
+    "sol = solve_ivp(lorenz, t_span, y0, max_step=0.01)\n",
+    "t = sol.t\n",
+    "x, y, z = sol.y\n",
+    "fig, axes = plt.subplots(3, 1, figsize=(6, 8), sharex=True)\n",
+    "axes[0].plot(t, x); axes[0].set_ylabel('x')\n",
+    "axes[1].plot(t, y); axes[1].set_ylabel('y')\n",
+    "axes[2].plot(t, z); axes[2].set_ylabel('z'); axes[2].set_xlabel('t')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0760078d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(6,4))\n",
+    "ax = fig.add_subplot(111, projection='3d')\n",
+    "ax.plot(x, y, z)\n",
+    "ax.set_xlabel('x')\n",
+    "ax.set_ylabel('y')\n",
+    "ax.set_zlabel('z')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70fdab05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y0_a = [1, 1, 1]\n",
+    "y0_b = [1.001, 1.001, 1.001]\n",
+    "sol_a = solve_ivp(lorenz, t_span, y0_a, max_step=0.01)\n",
+    "sol_b = solve_ivp(lorenz, t_span, y0_b, max_step=0.01)\n",
+    "diff = np.abs(sol_a.y - sol_b.y).sum(axis=0)\n",
+    "plt.figure(figsize=(6,4))\n",
+    "plt.plot(sol_a.t, diff)\n",
+    "plt.yscale('log')\n",
+    "plt.xlabel('t')\n",
+    "plt.ylabel('sum abs difference')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "fig = plt.figure(figsize=(6,4))\n",
+    "ax = fig.add_subplot(111, projection='3d')\n",
+    "ax.plot(sol_a.y[0], sol_a.y[1], sol_a.y[2], label='init=1,1,1')\n",
+    "ax.plot(sol_b.y[0], sol_b.y[1], sol_b.y[2], label='init=1.001')\n",
+    "ax.legend()\n",
+    "ax.set_xlabel('x'); ax.set_ylabel('y'); ax.set_zlabel('z')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- recreate Lorenz system demo from Mathematica notebook PS7.nb as a Python-based Jupyter notebook
- include trajectory plots and a simple sensitivity-to-initial-conditions example

## Testing
- `jupyter nbconvert --execute --to notebook PS7.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_689b562b22dc83239bc0ff516c99f8e8