### PR TITLE
Add Jupyter version of Ampere lab notebook

### DIFF
--- a/Ampere.ipynb
+++ b/Ampere.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f6a5250b",
+   "metadata": {},
+   "source": [
+    "# Lab 4: Magnetic Fields and Ampere's Law"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e392d62",
+   "metadata": {},
+   "source": [
+    "Charlie Bushman\n",
+    "\n",
+    "Phys 235 Lab #4\n",
+    "\n",
+    "04-30-19"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb4070bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Needs[\"ErrorBarPlots`\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11345c54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(* error propagation helper *)\\n\\n\\[Delta]Q[f_, p_, \\[Delta]_] := \\n    Sqrt[ Sum[ (D[f, p[[i]]] * \\[Delta][[i]])^2, {i, 1, Length[p]}] ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43035f4c",
+   "metadata": {},
+   "source": [
+    "## Section A: Calibration of the Hall sensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27d11f16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Clear[R, n, \\[Mu]0, b, \\[Delta]R, \\[Delta]b, Vr1, Vr2, Vr3, Vr4, Vr5, Vr6, Vr7, Vr8]\n",
+    "\n",
+    "data = {{1.18, Vr1}, {1.06, Vr2}, {0.960, Vr3}, {0.840, Vr4}, {0.720, Vr5}, {0.620, Vr6}, {0.520, Vr7}, {0.380, Vr8}};\n",
+    "\n",
+    "\\[Delta]1 = {0.04,0.02,0.02,0.02,0.02,0.02,0.02,0.02};\n",
+    "\\[Delta]2 = {0.04,0.04,0.04,0.04,0.04,0.04,0.04,0.04};\n",
+    "\n",
+    "f[x_] := {x[[1]], x[[2]]/R};\n",
+    "\n",
+    "fit = LinearModelFit[data, x, x, Weights -> 1/(\\[Delta]2^2), IncludeConstantBasis -> True];\n",
+    "propConst = fit[\"BestFitParameters\"][[2]];\n",
+    "\\[Delta]propConst = 3.6961*^-6;\n",
+    "propConst * \"V/T\" \\[PlusMinus] \\[Delta]propConst * \"V/T\";\n",
+    "\n",
+    "Show[\n",
+    "  ErrorListPlot[Table[{data[[i]], ErrorBar[\\[Delta]1[[i]], \\[Delta]2[[i]]]}, {i, 1, Length[data]}]],\n",
+    "  Plot[fit[x], {x, 0, 2}],\n",
+    "  AxesLabel -> {\"Magnetic Field (T)\", \"Hall Voltage (V)\"},\n",
+    "  ImageSize -> Full\n",
+    "]\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Convert Mathematica notebook `Ampere.nb` into an initial Jupyter notebook structure.
- Include title, author details, error propagation helper, and calibration workflow for the Hall sensor.

## Testing
- `python - <<'PY'
import nbformat
nb = nbformat.read('Ampere.ipynb', as_version=4)
for cell in nb.cells:
    print(cell.cell_type)
    print(cell.source.split('\n')[0][:80])
    print('---')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689b572f0004832387d141bf99d1f1b2