### PR TITLE
Convert Trebuchet.nb to starter Jupyter notebook

### DIFF
--- a/Trebuchet.ipynb
+++ b/Trebuchet.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ddab0703",
+   "metadata": {},
+   "source": [
+    "# Richard the Trebuchet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60ecdf63",
+   "metadata": {},
+   "source": [
+    "Charlie Bushman, Axel Stahl, Kyle Fraser-Mines, Jack Heinzel\n",
+    "Phys 231\n",
+    "Start: 03-09-19\n",
+    "Finish: 03-18-19"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30cc4ba3",
+   "metadata": {},
+   "source": [
+    "This notebook performs a computational analysis of the dynamics of a trebuchet as certain initial system parameters are varied. Section 0 sets up the simulation using a Lagrange multiplier to keep the projectile on a track until it lifts off. Section 1 explores the effect of the fulcrum offset on range, section 2 the effect of sling length, section 3 compares range with and without wheels, and section 4 studies how the initial counterweight position influences range."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c161acef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from scipy.integrate import solve_ivp\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Initial state parameters: r, theta, phi, sigma and their time derivatives\n",
+    "# list1 = [r0, theta0, phi0, sigma0, rdot0, thetadot0, phidot0, sigmadot0]\n",
+    "# Physical parameters stored in list2: [h, d, l1, l2, l3, l, m1, m2, m3, m4, g]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5890d313",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def simulate_treb1(list1, list2, tf=1.0):\n",
+    "    \"\"\"Simulate trebuchet motion while the projectile remains constrained to the track.\n",
+    "    This is a placeholder for the Lagrangian model with a constraint.\n",
+    "    \"\"\"\n",
+    "    # TODO: implement constrained dynamics using list1 and list2\n",
+    "    raise NotImplementedError(\"Trebuchet dynamics not yet implemented\")\n",
+    "\n",
+    "\n",
+    "def simulate_treb2(list1, list2, tf=1.0):\n",
+    "    \"\"\"Simulate trebuchet motion after the projectile leaves the track.\"\"\"\n",
+    "    # TODO: implement unconstrained dynamics\n",
+    "    raise NotImplementedError(\"Trebuchet dynamics not yet implemented\")\n",
+    "\n",
+    "\n",
+    "def simulate_treb(list1, list2, tf=1.0):\n",
+    "    \"\"\"Combine the two phases of the trebuchet launch.\n",
+    "    Uses simulate_treb1 until the constraint force goes to zero,\n",
+    "    then switches to simulate_treb2 for free motion.\n",
+    "    \"\"\"\n",
+    "    # TODO: call simulate_treb1 and simulate_treb2 appropriately\n",
+    "    raise NotImplementedError(\"Trebuchet dynamics not yet implemented\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fab8ffcf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example parameter sweep for fulcrum offset (placeholder)\n",
+    "offsets = np.linspace(-0.5, 0.5, 11)\n",
+    "range_results = []\n",
+    "for off in offsets:\n",
+    "    try:\n",
+    "        res = simulate_treb(list1, list2, tf=1.0)\n",
+    "    except NotImplementedError:\n",
+    "        res = np.nan\n",
+    "    range_results.append(res)\n",
+    "\n",
+    "plt.plot(offsets, range_results)\n",
+    "plt.xlabel('Fulcrum offset')\n",
+    "plt.ylabel('Range')\n",
+    "plt.title('Effect of fulcrum offset on range (placeholder)')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Create `Trebuchet.ipynb` with title, authors, and overview of trebuchet simulation study
- Stub out Python functions for constrained and unconstrained trebuchet dynamics
- Add placeholder analysis cell for sweeping fulcrum offset

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b576914c083238f0b9669278f7975