### PR TITLE
Add preliminary Thevenin Jupyter notebook

### DIFF
--- a/Thevenin.ipynb
+++ b/Thevenin.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "da07f057",
+   "metadata": {},
+   "source": [
+    "# Thevenin's Theorem\n",
+    "Converted from the original Mathematica notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d22d5a10",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "This notebook analyzes circuits to experimentally verify Thevenin's theorem and to estimate the effective resistance of a function generator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c51f5da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sympy as sp\n",
+    "\n",
+    "def delta_Q(f, params, deltas):\n",
+    "    \"\"\"Propagate uncertainty of function f with parameters params and their uncertainties deltas.\"\"\"\n",
+    "    return sp.sqrt(sum((sp.diff(f, p) * d)**2 for p, d in zip(params, deltas)))\n",
+    "\n",
+    "# Example: V = I * R with uncertainties in I and R\n",
+    "I, R = sp.symbols('I R')\n",
+    "V = I * R\n",
+    "DV = delta_Q(V, [I, R], [0.01, 0.1])\n",
+    "sp.simplify(DV)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f1ee08f",
+   "metadata": {},
+   "source": [
+    "Further analysis steps from the Mathematica notebook can be added here."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Convert original Thevenin Mathematica notebook into a starter Jupyter notebook.
- Include overview markdown and a SymPy function for propagating uncertainty.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b575fce2483239ecdf02d68037ff3